### PR TITLE
Call ::GD2::GD2FFI instead of GD2FFI

### DIFF
--- a/lib/gd2/canvas.rb
+++ b/lib/gd2/canvas.rb
@@ -58,7 +58,7 @@ module GD2
       end
 
       def draw(image, mode)
-        GD2FFI.send(:gdImageLine, image.image_ptr,
+        ::GD2::GD2FFI.send(:gdImageLine, image.image_ptr,
           @p1.x.to_i, @p1.y.to_i, @p2.x.to_i, @p2.y.to_i, mode.to_i)
         nil
       end
@@ -70,7 +70,7 @@ module GD2
       end
 
       def draw(image, mode)
-        GD2FFI.send(draw_sym, image.image_ptr, @p1.x.to_i, @p1.y.to_i, @p2.x.to_i, @p2.y.to_i, mode.to_i)
+        ::GD2::GD2FFI.send(draw_sym, image.image_ptr, @p1.x.to_i, @p1.y.to_i, @p2.x.to_i, @p2.y.to_i, mode.to_i)
         nil
       end
 
@@ -91,7 +91,7 @@ module GD2
       end
 
       def draw(image, mode)
-        GD2FFI.send(draw_sym, image.image_ptr, @points.map { |point|
+        ::GD2::GD2FFI.send(draw_sym, image.image_ptr, @points.map { |point|
           point.coordinates.pack('i_i_')
         }.join(''), @points.length, mode.to_i)
         nil
@@ -122,7 +122,7 @@ module GD2
       end
 
       def draw(image, mode)
-        GD2FFI.send(:gdImageArc, image.image_ptr, @center.x.to_i, @center.y.to_i,
+        ::GD2::GD2FFI.send(:gdImageArc, image.image_ptr, @center.x.to_i, @center.y.to_i,
           @width.to_i, @height.to_i,
           @range.begin.to_degrees.round.to_i, @range.end.to_degrees.round.to_i, mode.to_i)
         nil
@@ -144,7 +144,7 @@ module GD2
       end
 
       def draw(image, mode)
-        GD2FFI.send(:gdImageFilledArc, image.image_ptr, @center.x.to_i, @center.y.to_i,
+        ::GD2::GD2FFI.send(:gdImageFilledArc, image.image_ptr, @center.x.to_i, @center.y.to_i,
           @width.to_i, @height.to_i,
           @range.begin.to_degrees.round.to_i, @range.end.to_degrees.round.to_i,
           mode.to_i, style.to_i)
@@ -168,7 +168,7 @@ module GD2
       end
 
       def draw(image, mode)
-        GD2FFI.send(:gdImageArc, image.image_ptr, @center.x.to_i, @center.y.to_i,
+        ::GD2::GD2FFI.send(:gdImageArc, image.image_ptr, @center.x.to_i, @center.y.to_i,
           @width.to_i, @height.to_i, 0, 360, mode.to_i)
         nil
       end
@@ -176,7 +176,7 @@ module GD2
 
     class FilledEllipse < Ellipse
       def draw(image, mode)
-        GD2FFI.send(:gdImageFilledEllipse, image.image_ptr, @center.x.to_i, @center.y.to_i,
+        ::GD2::GD2FFI.send(:gdImageFilledEllipse, image.image_ptr, @center.x.to_i, @center.y.to_i,
           @width.to_i, @height.to_i, mode.to_i)
       end
     end
@@ -240,12 +240,12 @@ module GD2
     end
 
     def thickness=(thickness)
-      GD2FFI.send(:gdImageSetThickness, @image.image_ptr, @thickness = thickness.to_i)
+      ::GD2::GD2FFI.send(:gdImageSetThickness, @image.image_ptr, @thickness = thickness.to_i)
     end
 
     def style=(ary)
       if @style = ary
-        GD2FFI.send(:gdImageSetStyle, @image.image_ptr,
+        ::GD2::GD2FFI.send(:gdImageSetStyle, @image.image_ptr,
           ary.map { |c|
             !c ? TRANSPARENT : true == c ? -1 : @image.color2pixel(c)
           }, ary.length)
@@ -254,13 +254,13 @@ module GD2
 
     def brush=(image)
       if @brush = image
-        GD2FFI.send(:gdImageSetBrush, @image.image_ptr, image.image_ptr)
+        ::GD2::GD2FFI.send(:gdImageSetBrush, @image.image_ptr, image.image_ptr)
       end
     end
 
     def tile=(image)
       if @tile = image
-        GD2FFI.send(:gdImageSetTile, @image.image_ptr, image.image_ptr)
+        ::GD2::GD2FFI.send(:gdImageSetTile, @image.image_ptr, image.image_ptr)
       end
     end
 
@@ -339,13 +339,13 @@ module GD2
     end
 
     def fill
-      GD2FFI.send(:gdImageFill, @image.image_ptr, @point.x.to_i, @point.y.to_i, fill_pixel.to_i)
+      ::GD2::GD2FFI.send(:gdImageFill, @image.image_ptr, @point.x.to_i, @point.y.to_i, fill_pixel.to_i)
       self
     end
 
     def fill_to(border)
       # An apparent bug in gd prevents us from using fill_pixel
-      GD2FFI.send(:gdImageFillToBorder, @image.image_ptr, @point.x.to_i, @point.y.to_i,
+      ::GD2::GD2FFI.send(:gdImageFillToBorder, @image.image_ptr, @point.x.to_i, @point.y.to_i,
         @image.color2pixel(border), pixel.to_i)
       self
     end
@@ -412,10 +412,10 @@ module GD2
         BRUSHED
       elsif anti_aliasing?
         if @dont_blend
-          GD2FFI.send(:gdImageSetAntiAliasedDontBlend, @image.image_ptr,
+          ::GD2::GD2FFI.send(:gdImageSetAntiAliasedDontBlend, @image.image_ptr,
             pixel.to_i, @dont_blend.to_i)
         else
-          GD2FFI.send(:gdImageSetAntiAliased, @image.image_ptr, pixel.to_i)
+          ::GD2::GD2FFI.send(:gdImageSetAntiAliased, @image.image_ptr, pixel.to_i)
         end
         ANTI_ALIASED
       else

--- a/lib/gd2/color.rb
+++ b/lib/gd2/color.rb
@@ -215,7 +215,7 @@ module GD2
     # Alpha blend this color with the given color. If this color is associated
     # with a palette entry, this also modifies the palette.
     def alpha_blend!(other)
-      self.rgba = GD2FFI.send(:gdAlphaBlend, rgba.to_i, other.rgba.to_i)
+      self.rgba = ::GD2::GD2FFI.send(:gdAlphaBlend, rgba.to_i, other.rgba.to_i)
       self
     end
     alias << alpha_blend!

--- a/lib/gd2/ffi_struct.rb
+++ b/lib/gd2/ffi_struct.rb
@@ -70,7 +70,7 @@ module GD2::FFIStruct
     )
 
     def self.release(ptr)
-      GD2FFI.gdImageDestroy(ptr)
+      ::GD2::GD2FFI.gdImageDestroy(ptr)
     end
   end
 end

--- a/lib/gd2/font.rb
+++ b/lib/gd2/font.rb
@@ -50,14 +50,14 @@ module GD2
     private_class_method :new
 
     def self.font_ptr   #:nodoc:
-      GD2FFI.send(font_sym)
+      ::GD2::GD2FFI.send(font_sym)
     end
 
     def self.draw(image_ptr, x, y, angle, string, fg)   #:nodoc:
       raise ArgumentError, "Angle #{angle} not supported for #{self}" unless
         angle == 0.degrees || angle == 90.degrees
 
-      GD2FFI.send(angle > 0 ? :gdImageStringUp : :gdImageString, image_ptr,
+      ::GD2::GD2FFI.send(angle > 0 ? :gdImageStringUp : :gdImageString, image_ptr,
         font_ptr, x.to_i, y.to_i, string, fg.to_i)
       nil
     end
@@ -120,7 +120,7 @@ module GD2
 
         if count.zero?
           raise FreeTypeError, 'FreeType library failed to initialize' unless
-            GD2FFI.send(:gdFontCacheSetup).zero?
+            ::GD2::GD2FFI.send(:gdFontCacheSetup).zero?
         end
 
         ObjectSpace.define_finalizer(font, font_finalizer)
@@ -134,7 +134,7 @@ module GD2
     def self.unregister
       Thread.exclusive do
         @@fontcount -= 1
-        GD2FFI.send(:gdFontCacheShutdown) if @@fontcount.zero?
+        ::GD2::GD2FFI.send(:gdFontCacheShutdown) if @@fontcount.zero?
       end
     end
 
@@ -154,7 +154,7 @@ module GD2
     # library must have been built with fontconfig support. Raises an error if
     # fontconfig support is unavailable.
     def self.fontconfig=(want)
-      avail = !GD2FFI.send(:gdFTUseFontConfig, want ? 1 : 0).zero?
+      avail = !::GD2::GD2FFI.send(:gdFTUseFontConfig, want ? 1 : 0).zero?
       raise FontconfigError, 'Fontconfig not available' if want && !avail
       @@fontconfig = want
     end
@@ -228,12 +228,12 @@ module GD2
 
       strex = strex(false, true)
       args = [ nil, nil, 0, @fontname, @ptsize, 0.0, 0, 0, '', strex ]
-      r = GD2FFI.send(:gdImageStringFTEx, *args)
+      r = ::GD2::GD2FFI.send(:gdImageStringFTEx, *args)
 
       raise FreeTypeError.new(r.read_string) unless r.null?
       @fontpath = strex[:fontpath].read_string
     ensure
-      GD2FFI.send(:gdFree, strex[:fontpath])
+      ::GD2::GD2FFI.send(:gdFree, strex[:fontpath])
     end
 
     def inspect   #:nodoc:
@@ -251,7 +251,7 @@ module GD2
       strex = strex(true)
       args = [ image_ptr, brect, fg, @fontname, @ptsize, angle.to_f, x.to_i, y.to_i, string.gsub('&', '&amp;'), strex ]
 
-      r = GD2FFI.send(:gdImageStringFTEx, *args)
+      r = ::GD2::GD2FFI.send(:gdImageStringFTEx, *args)
       raise FreeTypeError.new(r.read_string) unless r.null?
       brect = brect.read_array_of_int(8)
 
@@ -259,7 +259,7 @@ module GD2
         begin
           xshow = xshow.read_string.split(' ').map { |e| e.to_f }
         ensure
-          GD2FFI.send(:gdFree, strex[:xshow])
+          ::GD2::GD2FFI.send(:gdFree, strex[:xshow])
         end
       else
         xshow = []
@@ -285,7 +285,7 @@ module GD2
       image_ptr, cx, cy, radius, text_radius, fill_portion,
       top, bottom, fgcolor
     ) #:nodoc:
-      r = GD2FFI.send(
+      r = ::GD2::GD2FFI.send(
         :gdImageStringFTCircle, image_ptr, cx.to_i, cy.to_i,
         radius.to_f, text_radius.to_f, fill_portion.to_f, @fontname, @ptsize,
         top || '', bottom || '', fgcolor.to_i

--- a/lib/gd2/image.rb
+++ b/lib/gd2/image.rb
@@ -114,7 +114,7 @@ module GD2
 
       type = data_type(magic) or
         raise UnrecognizedImageTypeError, 'Image data format is not recognized'
-      ptr = GD2FFI.send(create[type], *args)
+      ptr = ::GD2::GD2FFI.send(create[type], *args)
       raise LibraryError unless ptr
 
       ptr = FFIStruct::ImagePtr.new(ptr)
@@ -168,9 +168,9 @@ module GD2
       ptr = # TODO: implement xpm and xbm imports
       #if format == :xpm
         #raise ArgumentError, "Unexpected options #{options.inspect}" unless options.empty?
-        #GD2FFI.send(:gdImageCreateFromXpm, filename)
+        #::GD2::GD2FFI.send(:gdImageCreateFromXpm, filename)
       #elsif format == :xbm
-        #GD2FFI.send(:gdImageCreateFromXbm, filename)
+        #::GD2::GD2FFI.send(:gdImageCreateFromXbm, filename)
       if format == :gd2 && !options.empty?
         x, y, width, height =
           options.delete(:x) || 0, options.delete(:y) || 0,
@@ -182,7 +182,7 @@ module GD2
         raise ArgumentError, 'Missing required option :height' if height.nil?
         # TODO:
         ptr = File.open(filename, 'rb') do |file|
-          GD2FFI.send(:gdImageCreateFromGd2Part, file, x.to_i, y.to_i, width.to_i, height.to_i)
+          ::GD2::GD2FFI.send(:gdImageCreateFromGd2Part, file, x.to_i, y.to_i, width.to_i, height.to_i)
         end
       else
         raise ArgumentError, "Unexpected options #{options.inspect}" unless
@@ -204,7 +204,7 @@ module GD2
         file_ptr = FFI::MemoryPointer.new(file.size, 1, false)
         file_ptr.put_bytes(0, file)
 
-        GD2FFI.send(create_sym, file.size, file_ptr)
+        ::GD2::GD2FFI.send(create_sym, file.size, file_ptr)
       end
       raise LibraryError unless ptr
 
@@ -222,8 +222,8 @@ module GD2
     private_class_method :image_true_color?
 
     def self.create_image_ptr(sx, sy, alpha_blending = true)  #:nodoc:
-      ptr = FFIStruct::ImagePtr.new(GD2FFI.send(create_image_sym, sx.to_i, sy.to_i))
-      GD2FFI.send(:gdImageAlphaBlending, ptr, alpha_blending ? 1 : 0)
+      ptr = FFIStruct::ImagePtr.new(::GD2::GD2FFI.send(create_image_sym, sx.to_i, sy.to_i))
+      ::GD2::GD2FFI.send(:gdImageAlphaBlending, ptr, alpha_blending ? 1 : 0)
       ptr
     end
 
@@ -257,7 +257,7 @@ module GD2
     # identical, otherwise a bit field indicating the differences. See the
     # GD2::CMP_* constants for individual bit flags.
     def compare(other)
-      GD2FFI.send(:gdImageCompare, image_ptr, other.image_ptr)
+      ::GD2::GD2FFI.send(:gdImageCompare, image_ptr, other.image_ptr)
     end
 
     # Compare this image with another image. Returns *false* if the images are
@@ -297,13 +297,13 @@ module GD2
 
     # Return the pixel value at image location (+x+, +y+).
     def get_pixel(x, y)
-      GD2FFI.send(:gdImageGetPixel, @image_ptr, x.to_i, y.to_i)
+      ::GD2::GD2FFI.send(:gdImageGetPixel, @image_ptr, x.to_i, y.to_i)
     end
     alias pixel get_pixel
 
     # Set the pixel value at image location (+x+, +y+).
     def set_pixel(x, y, value)
-      GD2FFI.send(:gdImageSetPixel, @image_ptr, x.to_i, y.to_i, value.to_i)
+      ::GD2::GD2FFI.send(:gdImageSetPixel, @image_ptr, x.to_i, y.to_i, value.to_i)
       nil
     end
 
@@ -349,7 +349,7 @@ module GD2
     # Set whether this image will be stored in interlaced form when output as
     # PNG or JPEG.
     def interlaced=(bool)
-      GD2FFI.send(:gdImageInterlace, image_ptr, bool ? 1 : 0)
+      ::GD2::GD2FFI.send(:gdImageInterlace, image_ptr, bool ? 1 : 0)
     end
 
     # Return *true* if colors will be alpha blended into the image when pixels
@@ -363,7 +363,7 @@ module GD2
     # pixels are modified. Alpha blending is not available for IndexedColor
     # images.
     def alpha_blending=(bool)
-      GD2FFI.send(:gdImageAlphaBlending, image_ptr, bool ? 1 : 0)
+      ::GD2::GD2FFI.send(:gdImageAlphaBlending, image_ptr, bool ? 1 : 0)
     end
 
     # Return *true* if this image will be stored with full alpha channel
@@ -375,7 +375,7 @@ module GD2
     # Set whether this image will be stored with full alpha channel information
     # when output as PNG.
     def save_alpha=(bool)
-      GD2FFI.send(:gdImageSaveAlpha, image_ptr, bool ? 1 : 0)
+      ::GD2::GD2FFI.send(:gdImageSaveAlpha, image_ptr, bool ? 1 : 0)
     end
 
     # Return the transparent color for this image, or *nil* if none has been
@@ -387,7 +387,7 @@ module GD2
 
     # Set or unset the transparent color for this image.
     def transparent=(color)
-      GD2FFI.send(:gdImageColorTransparent, image_ptr,
+      ::GD2::GD2FFI.send(:gdImageColorTransparent, image_ptr,
         color.nil? ? -1 : color2pixel(color))
     end
 
@@ -399,7 +399,7 @@ module GD2
       x2 = FFI::MemoryPointer.new(:pointer)
       y2 = FFI::MemoryPointer.new(:pointer)
 
-      GD2FFI.send(:gdImageGetClip, image_ptr, x1, y1, x2, y2)
+      ::GD2::GD2FFI.send(:gdImageGetClip, image_ptr, x1, y1, x2, y2)
       [ x1.read_int, y1.read_int, x2.read_int, y2.read_int ]
     end
 
@@ -410,18 +410,18 @@ module GD2
       clip = clipping
       begin
         p clipping
-        GD2FFI.send(:gdImageSetClip, image_ptr, x1.to_i, y1.to_i, x2.to_i, y2.to_i)
+        ::GD2::GD2FFI.send(:gdImageSetClip, image_ptr, x1.to_i, y1.to_i, x2.to_i, y2.to_i)
         p clipping
         yield self
         self
       ensure
-        GD2FFI.send(:gdImageSetClip, image_ptr, *clip)
+        ::GD2::GD2FFI.send(:gdImageSetClip, image_ptr, *clip)
       end
     end
 
     # Return *true* if the current clipping rectangle excludes the given point.
     def clips?(x, y)
-      GD2FFI.send(:gdImageBoundsSafe, image_ptr, x.to_i, y.to_i).zero?
+      ::GD2::GD2FFI.send(:gdImageBoundsSafe, image_ptr, x.to_i, y.to_i).zero?
     end
 
     # Provide a drawing environment for a block. See GD2::Canvas.
@@ -482,10 +482,10 @@ module GD2
 
       File.open(filename, 'wb') do |file|
         begin
-          img = GD2FFI.send(write_sym, image_ptr, *args)
+          img = ::GD2::GD2FFI.send(write_sym, image_ptr, *args)
           file.write(img.get_bytes(0, size.get_int(0)))
         ensure
-          GD2FFI.gdFree(img)
+          ::GD2::GD2FFI.gdFree(img)
         end
       end
     end
@@ -495,10 +495,10 @@ module GD2
     # implying both higher quality and larger sizes.
     def jpeg(quality = nil)
       size = FFI::MemoryPointer.new(:pointer)
-      ptr = GD2FFI.send(:gdImageJpegPtr, image_ptr, size, quality || -1)
+      ptr = ::GD2::GD2FFI.send(:gdImageJpegPtr, image_ptr, size, quality || -1)
       ptr.get_bytes(0, size.get_int(0))
     ensure
-      GD2FFI.send(:gdFree, ptr)
+      ::GD2::GD2FFI.send(:gdFree, ptr)
     end
 
     # Encode and return data for this image in PNG format. The +level+
@@ -506,10 +506,10 @@ module GD2
     # compression (0 = none, 1 = minimal but fast, 9 = best but slow).
     def png(level = nil)
       size = FFI::MemoryPointer.new(:pointer)
-      ptr = GD2FFI.send(:gdImagePngPtrEx, image_ptr, size, level.to_i || -1)
+      ptr = ::GD2::GD2FFI.send(:gdImagePngPtrEx, image_ptr, size, level.to_i || -1)
       ptr.get_bytes(0, size.get_int(0))
     ensure
-      GD2FFI.send(:gdFree, ptr)
+      ::GD2::GD2FFI.send(:gdFree, ptr)
     end
 
     # Encode and return data for this image in GIF format. Note that GIF only
@@ -518,10 +518,10 @@ module GD2
     # Image#to_indexed_color to control this conversion more precisely.
     def gif
       size = FFI::MemoryPointer.new(:pointer)
-      ptr = GD2FFI.send(:gdImageGifPtr, image_ptr, size)
+      ptr = ::GD2::GD2FFI.send(:gdImageGifPtr, image_ptr, size)
       ptr.get_bytes(0, size.get_int(0))
     ensure
-      GD2FFI.send(:gdFree, ptr)
+      ::GD2::GD2FFI.send(:gdFree, ptr)
     end
 
     # Encode and return data for this image in WBMP format. WBMP currently
@@ -530,20 +530,20 @@ module GD2
     # considered “background” (white).
     def wbmp(fgcolor)
       size = FFI::MemoryPointer.new(:pointer)
-      ptr = GD2FFI.send(:gdImageWBMPPtr, image_ptr, size, color2pixel(fgcolor))
+      ptr = ::GD2::GD2FFI.send(:gdImageWBMPPtr, image_ptr, size, color2pixel(fgcolor))
       ptr.get_bytes(0, size.get_int(0))
     ensure
-      GD2FFI.send(:gdFree, ptr)
+      ::GD2::GD2FFI.send(:gdFree, ptr)
     end
 
     # Encode and return data for this image in “.gd” format. This is an
     # internal format used by the gd library to quickly read and write images.
     def gd
       size = FFI::MemoryPointer.new(:pointer)
-      ptr = GD2FFI.send(:gdImageGdPtr, image_ptr, size)
+      ptr = ::GD2::GD2FFI.send(:gdImageGdPtr, image_ptr, size)
       ptr.get_bytes(0, size.get_int(0))
     ensure
-      GD2FFI.send(:gdFree, ptr)
+      ::GD2::GD2FFI.send(:gdFree, ptr)
     end
 
     # Encode and return data for this image in “.gd2” format. This is an
@@ -551,10 +551,10 @@ module GD2
     # The specified +fmt+ may be either GD2::FMT_RAW or GD2::FMT_COMPRESSED.
     def gd2(fmt = FMT_COMPRESSED, chunk_size = 0)
       size = FFI::MemoryPointer.new(:pointer)
-      ptr = GD2FFI.send(:gdImageGd2Ptr, image_ptr, chunk_size.to_i, fmt.to_i, size)
+      ptr = ::GD2::GD2FFI.send(:gdImageGd2Ptr, image_ptr, chunk_size.to_i, fmt.to_i, size)
       ptr.get_bytes(0, size.get_int(0))
     ensure
-      GD2FFI.send(:gdFree, ptr)
+      ::GD2::GD2FFI.send(:gdFree, ptr)
     end
 
     # Copy a portion of another image to this image. If +src_w+ and +src_h+ are
@@ -564,10 +564,10 @@ module GD2
         dst_w, dst_h, src_w = nil, src_h = nil)
       raise ArgumentError unless src_w.nil? == src_h.nil?
       if src_w
-        GD2FFI.send(:gdImageCopyResampled, image_ptr, other.image_ptr,
+        ::GD2::GD2FFI.send(:gdImageCopyResampled, image_ptr, other.image_ptr,
           dst_x.to_i, dst_y.to_i, src_x.to_i, src_y.to_i, dst_w.to_i, dst_h.to_i, src_w.to_i, src_h.to_i)
       else
-        GD2FFI.send(:gdImageCopy, image_ptr, other.image_ptr,
+        ::GD2::GD2FFI.send(:gdImageCopy, image_ptr, other.image_ptr,
           dst_x.to_i, dst_y.to_i, src_x.to_i, src_y.to_i, dst_w.to_i, dst_h.to_i)
       end
       self
@@ -578,7 +578,7 @@ module GD2
     # +dst_y+ arguments indicate the _center_ of the desired destination, and
     # may be floating point.
     def copy_from_rotated(other, dst_x, dst_y, src_x, src_y, w, h, angle)
-      GD2FFI.send(:gdImageCopyRotated, image_ptr, other.image_ptr,
+      ::GD2::GD2FFI.send(:gdImageCopyRotated, image_ptr, other.image_ptr,
         dst_x.to_f, dst_y.to_f, src_x.to_i, src_y.to_i, w.to_i, h.to_i, angle.to_degrees.round.to_i)
       self
     end
@@ -588,7 +588,7 @@ module GD2
     # Image#copy_from; a percentage of 0.0 is a no-op. Note that alpha
     # channel information from the source image is ignored.
     def merge_from(other, dst_x, dst_y, src_x, src_y, w, h, pct)
-      GD2FFI.send(:gdImageCopyMerge, image_ptr, other.image_ptr,
+      ::GD2::GD2FFI.send(:gdImageCopyMerge, image_ptr, other.image_ptr,
         dst_x.to_i, dst_y.to_i, src_x.to_i, src_y.to_i, w.to_i, h.to_i, pct.to_percent.round.to_i)
       self
     end
@@ -597,7 +597,7 @@ module GD2
     # coordinates. Note that some of the edges of the image may be lost.
     def rotate!(angle, axis_x = width / 2.0, axis_y = height / 2.0)
       ptr = self.class.create_image_ptr(width, height, alpha_blending?)
-      GD2FFI.send(:gdImageCopyRotated, ptr, image_ptr,
+      ::GD2::GD2FFI.send(:gdImageCopyRotated, ptr, image_ptr,
         axis_x.to_f, axis_y.to_f, 0, 0, width.to_i, height.to_i, angle.to_degrees.round.to_i)
       init_with_image(ptr)
     end
@@ -611,7 +611,7 @@ module GD2
     # (0, 0).
     def crop!(x, y, w, h)
       ptr = self.class.create_image_ptr(w, h, alpha_blending?)
-      GD2FFI.send(:gdImageCopy, ptr, image_ptr, 0, 0, x.to_i, y.to_i, w.to_i, h.to_i)
+      ::GD2::GD2FFI.send(:gdImageCopy, ptr, image_ptr, 0, 0, x.to_i, y.to_i, w.to_i, h.to_i)
       init_with_image(ptr)
     end
 
@@ -625,7 +625,7 @@ module GD2
     def uncrop!(x1, y1 = x1, x2 = x1, y2 = y1)
       ptr = self.class.create_image_ptr(x1 + width + x2, y1 + height + y2,
         alpha_blending?)
-      GD2FFI.send(:gdImageCopy, ptr, image_ptr, x1.to_i, y1.to_i, 0, 0, width.to_i, height.to_i)
+      ::GD2::GD2FFI.send(:gdImageCopy, ptr, image_ptr, x1.to_i, y1.to_i, 0, 0, width.to_i, height.to_i)
       init_with_image(ptr)
     end
 
@@ -639,7 +639,7 @@ module GD2
     # shrunk as necessary without resampling.
     def resize!(w, h, resample = true)
       ptr = self.class.create_image_ptr(w, h, false)
-      GD2FFI.send(resample ? :gdImageCopyResampled : :gdImageCopyResized,
+      ::GD2::GD2FFI.send(resample ? :gdImageCopyResampled : :gdImageCopyResized,
         ptr, image_ptr, 0, 0, 0, 0, w.to_i, h.to_i, width.to_i, height.to_i)
       alpha_blending = alpha_blending?
       init_with_image(ptr)
@@ -658,7 +658,7 @@ module GD2
     # Note that the original image must be square.
     def polar_transform!(radius)
       raise 'Image must be square' unless width == height
-      ptr = GD2FFI.send(:gdImageSquareToCircle, image_ptr, radius.to_i)
+      ptr = ::GD2::GD2FFI.send(:gdImageSquareToCircle, image_ptr, radius.to_i)
       raise LibraryError unless ptr
       init_with_image(ptr)
     end
@@ -684,7 +684,7 @@ module GD2
     # +colors+ indicates the maximum number of palette colors to use, and
     # +dither+ controls whether dithering is used.
     def to_indexed_color(colors = MAX_COLORS, dither = true)
-      ptr = GD2FFI.send(:gdImageCreatePaletteFromTrueColor,
+      ptr = ::GD2::GD2FFI.send(:gdImageCreatePaletteFromTrueColor,
         to_true_color.image_ptr, dither ? 1 : 0, colors.to_i)
       raise LibraryError unless ptr
 
@@ -766,7 +766,7 @@ module GD2
     # grey scale before the merge.
     def merge_from(other, dst_x, dst_y, src_x, src_y, w, h, pct, gray = false)
       return super(other, dst_x, dst_y, src_x, src_y, w, h, pct) unless gray
-      GD2FFI.send(:gdImageCopyMergeGray, image_ptr, other.image_ptr,
+      ::GD2::GD2FFI.send(:gdImageCopyMergeGray, image_ptr, other.image_ptr,
         dst_x.to_i, dst_y.to_i, src_x.to_i, src_y.to_i, w.to_i, h.to_i, pct.to_percent.round.to_i)
       self
     end
@@ -788,7 +788,7 @@ module GD2
     end
 
     def sharpen(pct)  #:nodoc:
-      GD2FFI.send(:gdImageSharpen, image_ptr, pct.to_percent.round.to_i)
+      ::GD2::GD2FFI.send(:gdImageSharpen, image_ptr, pct.to_percent.round.to_i)
       self
     end
   end

--- a/lib/gd2/palette.rb
+++ b/lib/gd2/palette.rb
@@ -103,7 +103,7 @@ module GD2
     # a color from the palette that is closest to it.
     def resolve(color)
       raise TypeError unless color.kind_of? Color
-      c = GD2FFI.send(:gdImageColorResolveAlpha, @image.image_ptr,
+      c = ::GD2::GD2FFI.send(:gdImageColorResolveAlpha, @image.image_ptr,
         color.red.to_i, color.green.to_i, color.blue.to_i, color.alpha.to_i)
       c == -1 ? nil : get_color(c)
     end
@@ -112,7 +112,7 @@ module GD2
     # if the color is not presently in the palette.
     def exact(color)
       raise TypeError unless color.kind_of? Color
-      c = GD2FFI.send(:gdImageColorExactAlpha, @image.image_ptr,
+      c = ::GD2::GD2FFI.send(:gdImageColorExactAlpha, @image.image_ptr,
         color.red.to_i, color.green.to_i, color.blue.to_i, color.alpha.to_i)
       c == -1 ? nil : get_color(c)
     end
@@ -128,7 +128,7 @@ module GD2
     # according to Euclidian distance.
     def closest(color)
       raise TypeError unless color.kind_of? Color
-      c = GD2FFI.send(:gdImageColorClosestAlpha, @image.image_ptr,
+      c = ::GD2::GD2FFI.send(:gdImageColorClosestAlpha, @image.image_ptr,
         color.red.to_i, color.green.to_i, color.blue.to_i, color.alpha.to_i)
       c == -1 ? nil : get_color(c)
     end
@@ -137,7 +137,7 @@ module GD2
     # according to hue, whiteness, and blackness.
     def closest_hwb(color)
       raise TypeError unless color.kind_of? Color
-      c = GD2FFI.send(:gdImageColorClosestHWB, @image.image_ptr,
+      c = ::GD2::GD2FFI.send(:gdImageColorClosestHWB, @image.image_ptr,
         color.red.to_i, color.green.to_i, color.blue.to_i)
       c == -1 ? nil : get_color(c)
     end
@@ -147,7 +147,7 @@ module GD2
     # raises an error for Image::IndexedColor palettes if the palette is full.
     def allocate(color)
       raise TypeError unless color.kind_of? Color
-      c = GD2FFI.send(:gdImageColorAllocateAlpha, @image.image_ptr,
+      c = ::GD2::GD2FFI.send(:gdImageColorAllocateAlpha, @image.image_ptr,
         color.red.to_i, color.green.to_i, color.blue.to_i, color.alpha.to_i)
       c == -1 ? raise(Palette::PaletteFullError, 'Palette is full') :
         get_color(c)
@@ -164,7 +164,7 @@ module GD2
     def deallocate(color)
       color = exact(color) unless color.index
       return nil if color.nil? || color.index.nil?
-      GD2FFI.send(:gdImageColorDeallocate, @image.image_ptr, color.index.to_i)
+      ::GD2::GD2FFI.send(:gdImageColorDeallocate, @image.image_ptr, color.index.to_i)
       nil
     end
 


### PR DESCRIPTION
The `GD2FFI` module is not always visible from other classes. For example, when `GD2FFI` is called in `GD2::FFIStruct` then Ruby intepreter will search both for `::GD2FFI` and `GD2::FFIStruct::GD2FFI`, but not for `::GD2::GD2FFI`.

We have to define explicit global calls to the necessary module.
