### PR TITLE
add debian/ubuntu paths for x86_64, propery use the ENV variable

### DIFF
--- a/lib/gd2-ffij.rb
+++ b/lib/gd2-ffij.rb
@@ -34,9 +34,9 @@ module GD2
         'cyggd-2.dll'
       else
         paths = if ENV['GD2_LIBRARY_PATH']
-          ENV['GD2_LIBRARY_PATH']
+          [ ENV['GD2_LIBRARY_PATH'] ]
         else
-          [ '/usr/local/{lib64,lib}', '/opt/local/{lib64,lib}', '/usr/{lib64,lib}' ]
+          [ '/usr/local/{lib64,lib}', '/opt/local/{lib64,lib}', '/usr/{lib64,lib}', '/usr/lib/x86_64-linux-gnu' ]
         end
 
         lib = if [


### PR DESCRIPTION
The ENV variable could be set, but it would fail later on in the collect call, since a string doesn't have a .collect method.

On debian and ubuntu x86_64, the library path is different, so add it to the mix.
