### PR TITLE
Add debian paths for i386

### DIFF
--- a/lib/gd2-ffij.rb
+++ b/lib/gd2-ffij.rb
@@ -36,7 +36,7 @@ module GD2
         paths = if ENV['GD2_LIBRARY_PATH']
           [ ENV['GD2_LIBRARY_PATH'] ]
         else
-          [ '/usr/local/{lib64,lib}', '/opt/local/{lib64,lib}', '/usr/{lib64,lib}', '/usr/lib/x86_64-linux-gnu' ]
+          [ '/usr/local/{lib64,lib}', '/opt/local/{lib64,lib}', '/usr/{lib64,lib}', '/usr/lib/{x86_64,i386}-linux-gnu' ]
         end
 
         lib = if [


### PR DESCRIPTION
Hi, 

Our testing machine has a i386 debian and gd2-ffij was unavailable to find libgd2.so.2 libary with the current paths.

So, I added in this little fix.

Thanks
