### PR TITLE
Revert use of autoload

### DIFF
--- a/lib/gd2-ffij.rb
+++ b/lib/gd2-ffij.rb
@@ -190,20 +190,13 @@ module GD2
 
   GD2_BASE = File.join(File.dirname(__FILE__), 'gd2')
 
-  autoload :Image,
-    File.join(GD2_BASE, 'image')
-  autoload :Color,
-    File.join(GD2_BASE, 'color')
-  autoload :Palette,
-    File.join(GD2_BASE, 'palette')
-  autoload :Canvas,
-    File.join(GD2_BASE, 'canvas')
-  autoload :Font,
-    File.join(GD2_BASE, 'font')
-  autoload :FFIStruct,
-    File.join(GD2_BASE, 'ffi_struct')
-  autoload :AnimatedGif,
-    File.join(GD2_BASE, 'animated_gif')
+  require File.join(GD2_BASE, 'image')
+  require File.join(GD2_BASE, 'color')
+  require File.join(GD2_BASE, 'palette')
+  require File.join(GD2_BASE, 'canvas')
+  require File.join(GD2_BASE, 'font')
+  require File.join(GD2_BASE, 'ffi_struct')
+  require File.join(GD2_BASE, 'animated_gif')
 end
 
 class Numeric


### PR DESCRIPTION
Hi, I'm using this module on OpenBSD in an environment that uses its [`pledge`](https://man.openbsd.org/pledge.2) mechanism to restrict the functionality of the program for increased security when parsing untrusted images.

The 0.4.0 release of gd2-ffij [changed the behavior](https://github.com/dark-panda/gd2-ffij/commit/020191e1611a4afa907bcee5b75501c67bf36c76#diff-db34ca9f592fa0fce78037c3824d5227L192-R207) to `autoload` classes at runtime, which breaks my application because it's not allowed to read additional files once `pledge` has been called.  The previous release used `require` so the entirety of the gd2-ffij module was loaded by the time my application called `pledge` to lock things down.

Could this use of `autoload` be reverted to go back to `require` each dependency up front?