### PR TITLE
Modifications for Ruby 3.1.

### DIFF
--- a/gd2-ffij.gemspec
+++ b/gd2-ffij.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency('ffi', ['>= 1.0.0'])
+  s.add_dependency('matrix')
 end

--- a/lib/gd2/animated_gif.rb
+++ b/lib/gd2/animated_gif.rb
@@ -65,15 +65,15 @@ class GD2::AnimatedGif
 
       @frames = []
 
-      ObjectSpace.define_finalizer(@frames, frames_finalizer)
+      ObjectSpace.define_finalizer(self, self.class.frames_finalizer(@frames))
 
       @frames
     end
 
-    def frames_finalizer
+    def self.frames_finalizer(frames)
       proc do
-        each do |frame|
-          ::GD2::GD2FFI.send(:gdFree, frame[:frame_ptr])
+        frames.each do |frame|
+          ::GD2::GD2FFI.send(:gdFree, frame[:ptr])
         end
       end
     end


### PR DESCRIPTION
Hi!

I was getting some warnings when running the test suite from https://github.com/openstreetmap/openstreetmap-website saying things like:

```
/home/matt/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.0.5/lib/active_support/testing/parallelization/worker.rb:15: warning: Exception in finalizer #<Proc:0x00007f069eb3bab8 /home/matt/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/gd2-ffij-0.4.0/lib/gd2/animated_gif.rb:73>
/home/matt/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/gd2-ffij-0.4.0/lib/gd2/animated_gif.rb:74:in `block in frames_finalizer': undefined method `each' for #<GD2::AnimatedGif:0x00007f069eb3bba8 @frames=[#<struct GD2::AnimatedGif::Frame ptr=#<FFI::Pointer address=0x00005616f01ff470>, size=#<FFI::MemoryPointer address=0x00005616e9b1bb30 size=4>>, #<struct GD2::AnimatedGif::Frame ptr=#<FFI::Pointer address=0x00005616f01ff4b0>, size=#<FFI::MemoryPointer address=0x00005616e9e38a00 size=4>>, #<struct GD2::AnimatedGif::Frame ptr=#<FFI::Pointer address=0x00005616f01ff630>, size=#<FFI::MemoryPointer address=0x00005616e9caeda0 size=4>>, #<struct GD2::AnimatedGif::Frame ptr=#<FFI::Pointer address=0x00005616f01ff7b0>, size=#<FFI::MemoryPointer address=0x00005616ed2b1210 size=4>>, #<struct GD2::AnimatedGif::Frame ptr=#<FFI::Pointer address=0x00005616f01ff930>, size=#<FFI::MemoryPointer address=0x00005616eec24430 size=4>>, #<struct GD2::AnimatedGif::Frame ptr=#<FFI::Pointer address=0x00005616f01ffab0>, size=#<FFI::MemoryPointer address=0x00005616ed070520 size=4>>, #<struct GD2::AnimatedGif::Frame ptr=#<FFI::Pointer address=0x00005616f01ffc30>, size=#<FFI::MemoryPointer address=0x00005616e9aff6e0 size=4>>, #<struct GD2::AnimatedGif::Frame ptr=#<FFI::Pointer address=0x00005616f01ffdb0>, size=#<FFI::MemoryPointer address=0x00005616ef5d2db0 size=4>>, #<struct GD2::AnimatedGif::Frame ptr=#<FFI::Pointer address=0x00005616f01fff30>, size=#<FFI::MemoryPointer address=0x00005616efa6b480 size=4>>, #<struct GD2::AnimatedGif::Frame ptr=#<FFI::Pointer address=0x00005616f02000b0>, size=#<FFI::MemoryPointer address=0x00005616e9c81f20 size=4>>, #<struct GD2::AnimatedGif::Frame ptr=#<FFI::Pointer address=0x00005616f0200230>, size=#<FFI::MemoryPointer address=0x00005616ecf8bba0 size=4>>, #<struct GD2::AnimatedGif::Frame ptr=#<FFI::Pointer address=0x00005616ef5dbd70>, size=#<FFI::MemoryPointer address=0x00005616ed20d080 size=4>>]> (NoMethodError)

        each do |frame|
        ^^^^
...
```

I'm not entirely sure why the finalizer is behaving differently now, but changing it to a proc capturing `@frames` instead of on `@frames` itself seemed to work for me, and is [recommended in the Ruby 3.1 docs](https://ruby-doc.org/3.1.4/ObjectSpace.html#method-c-define_finalizer).

Also, Ruby 3.1 removed the "matrix" library from the standard lib, so it now needs to be required as a gem. Thanks @gravitystorm for showing me the right way to do that! I tested on 2.7 as well, and it looked like depending on "matrix" was OK there too.