### PR TITLE
Support aarch64 library location

### DIFF
--- a/lib/gd2-ffij.rb
+++ b/lib/gd2-ffij.rb
@@ -70,7 +70,7 @@ module GD2
             '/usr/local/{lib64,lib}',
             '/opt/local/{lib64,lib}',
             '/usr/{lib64,lib}',
-            '/usr/lib/{x86_64,i386}-linux-gnu',
+            '/usr/lib/{x86_64,i386,aarch64}-linux-gnu',
             '/usr/lib/arm-linux*'
           ]
 


### PR DESCRIPTION
Add support for the aarch64 architecture in the library search path to improve compatibility with Apple Silicon when running this gem inside a Docker container.